### PR TITLE
Minimaalinen lisäys erikoismerkkejä korjaavaan luokkaanne

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Ohtu 2016 miniprojekti
 [Product Backlog](https://docs.google.com/spreadsheets/d/17cuWSJdrXupCiSLn5XclZlMT1ibx3-jwUHZeIaH46WQ/edit#gid=0)
 
 [Sprint Backlog](https://docs.google.com/spreadsheets/d/17cuWSJdrXupCiSLn5XclZlMT1ibx3-jwUHZeIaH46WQ/edit#gid=306295527)
+
+Laskaririvi.

--- a/src/main/java/kivaryhma/services/CharacterEscaper.java
+++ b/src/main/java/kivaryhma/services/CharacterEscaper.java
@@ -24,6 +24,12 @@ public class CharacterEscaper {
         text = text.replace("Æ", "{\\AE}");
         text = text.replace("ø", "{\\o}");
         text = text.replace("Ø", "{\\O}");
+
+        // special characters {  "  and $  also need to be vetted from BibteX with extra slashes.
+        text = text.replace("{", "\\{");
+        text = text.replace("\"", "\\\"");
+        text = text.replace("$", "\\$");
+         
         //Testikommentti
         return text;
         


### PR DESCRIPTION
CharacterEscaper-filtterinne ei huomioinut muutamaa erikoismerkkiä:

"some characters can not be put directly into a BibTeX-entry, as they would conflict with the format description, like {, " or $. They need to be escaped using a backslash (\)."

